### PR TITLE
fix: add focus styles fallback for IE11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/ods-inputoptions",
-  "version": "1.1.2",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6636,6 +6636,12 @@
         "p-is-promise": "^2.0.0"
       }
     },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true
+    },
     "meow": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
@@ -11200,6 +11206,36 @@
         }
       }
     },
+    "npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -11795,6 +11831,12 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
       "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
+      "dev": true
+    },
+    "pidtree": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
+      "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==",
       "dev": true
     },
     "pify": {
@@ -13436,6 +13478,12 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shell-quote": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -13818,6 +13866,17 @@
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^5.1.0"
+      }
+    },
+    "string.prototype.padend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.4.3",
+        "function-bind": "^1.0.2"
       }
     },
     "string.prototype.repeat": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "jsonlint": "^1.6.3",
     "lodash": "^4.17.11",
     "mocha": "^6.1.4",
+    "npm-run-all": "^4.1.5",
     "npm-watch": "^0.6.0",
     "postcss": "^7.0.17",
     "postcss-custom-properties": "^8.0.10",
@@ -97,6 +98,10 @@
     "stylefluxCanonical": "styleflux -o ./altImports/canonical/*.css",
     "stylefluxVariable": "styleflux -o ./altImports/variable/*.css",
     "sweep": "rm -rf ./altImports ./temp ./demo/css ./demo/fonts ./dist ./src/tokens | rm ./demo/sass/*token*.scss ./src/*.css ./src/*-css.js",
+    "processSrc": "gulp processSrc",
+    "processImportsCanonical": "gulp processImportsCanonical",
+    "processImportsVariable": "gulp processImportsVariable",
+    "ciBuild": "npm-run-all buildTokens processSrc processImportsCanonical processImportsVariable stylefluxCanonical stylefluxVariable distTokens sassRender distJS",
     "test": "npm run cssLint | npm run jsonLint | yamllint .travis.yml"
   },
   "husky": {

--- a/src/style.scss
+++ b/src/style.scss
@@ -36,7 +36,7 @@
     }
   }
 
-  /* Fallback for browsers that don't support focus-within */ 
+  /* Fallback for browsers that don't support focus-within */
   .ods-inputOption:focus {
     & + .ods-inputLabel {
       background-color: var(--host-focus-inputgroup-background-color);
@@ -46,12 +46,11 @@
         border-color: var(--color-base-shark);
       }
     }
-  } 
+  }
 
   .ods-inputGroup:focus-within {
     width: var(--host-focus-inputgroup-width);
     display: var(--host-focus-inputgroup-display);
-    color: var(--host-focus-inputgroup-color);
     background-color: var(--host-focus-inputgroup-background-color);
 
     padding-right: var(--host-focus-inputgroup-padding-right);

--- a/src/style.scss
+++ b/src/style.scss
@@ -36,6 +36,18 @@
     }
   }
 
+  /* Fallback for browsers that don't support focus-within */ 
+  .ods-inputOption:focus {
+    & + .ods-inputLabel {
+      background-color: var(--host-focus-inputgroup-background-color);
+      color: var(--host-focus-inputgroup-color);
+
+      &:after {
+        border-color: var(--color-base-shark);
+      }
+    }
+  } 
+
   .ods-inputGroup:focus-within {
     width: var(--host-focus-inputgroup-width);
     display: var(--host-focus-inputgroup-display);


### PR DESCRIPTION
# Alaska Airlines Pull Request

IE 11 was not rendering focus styles on the input options when tabbing. This fallback achieves a similar effect, but is not a perfect replica (see image below). Focus styles should not change in browsers that support focus-within.

![image](https://user-images.githubusercontent.com/4992896/68816260-c0bd8a00-0632-11ea-8f26-161c7c3a3410.png)

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
