### PR TITLE
fix: use change event instead of input event

### DIFF
--- a/src/ods-inputoptions.js
+++ b/src/ods-inputoptions.js
@@ -66,7 +66,7 @@ class OdsInputoptions extends LitElement {
     }
   }
 
-  handleInput({target}) {
+  handleChange({target}) {
     if (target.checked && this.type === `checkbox`) {
       this.dispatchEvent(new CustomEvent('input', {
         composed: true,
@@ -116,7 +116,7 @@ class OdsInputoptions extends LitElement {
 
         html`
           <div
-            @input=${this.handleInput}
+            @change=${this.handleChange}
             class="${ifDefined(this.horizontal ? this.getHorizontal(this.horizontal) : undefined)}">
 
             ${this.componentData.map(i => html`


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Summary:

When used in IE11, the radio buttons were not dispatching a custom input event on selection. This is because IE11 does not trigger an input event for radio buttons, and the component was listening to that input. Using the change event instead of the input event will allow us to support IE11.

## Type of change:

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
